### PR TITLE
Update package.json to remove warnings at install time

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
   },
   "main": "geode.js",
   "engines": {
-    "node": "0.8"
+    "node": "<=0.10"
   },
   "dependencies": {
-    "request" : "latest"
+    "request" : "^2.53.0"
   },
   "devDependencies": {
       "mocha": "*",


### PR DESCRIPTION
Set min node version to 0.10 (request does not support 0.12 yet) and fixed the request version ("latest" should not be used - maybe "request" changes its API?)